### PR TITLE
Fix missing Celery task reference

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,7 @@ from celery.result import AsyncResult
 # --- Local Imports ---
 from . import models, schemas, security
 from .database import engine, Base, get_db
-from .worker import run_trace_pipeline  # Import the Celery task
+from .worker import run_trace_pipeline, add_numbers  # Import Celery tasks
 
 # --- Lifespan and App Initialization ---
 @asynccontextmanager

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -20,6 +20,12 @@ celery_app.conf.update(
     enable_utc=True,
 )
 
+# Simple demo task for verifying Celery functionality
+@celery_app.task(name="add_numbers")
+def add_numbers(x: int, y: int) -> int:
+    """Return the sum of two integers."""
+    return x + y
+
 @celery_app.task(bind=True)
 def run_trace_pipeline(self, job_id: int, input_file_path: str, sample_id: str, data_type: str):
     """


### PR DESCRIPTION
## Summary
- define `add_numbers` task for Celery
- import it in the FastAPI app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa6921f0c83229cb020485eaca2e8